### PR TITLE
Bump marshmallow from 3.12.2 to 3.16.0

### DIFF
--- a/platform_service_accounts_api/schema.py
+++ b/platform_service_accounts_api/schema.py
@@ -43,7 +43,7 @@ def validate_name(name: str) -> None:
 
 
 class ServiceAccountCreateSchema(Schema):
-    name = fields.String(required=False, missing=None, validate=validate_name)
+    name = fields.String(required=False, load_default=None, validate=validate_name)
     default_cluster = fields.String(required=True)
 
 
@@ -52,7 +52,7 @@ class ServiceAccountSchema(ServiceAccountCreateSchema):
     role = fields.String(required=True)
     owner = fields.String(required=True)
     created_at = fields.AwareDateTime(required=True)
-    role_deleted = fields.Boolean(required=True, default=False)
+    role_deleted = fields.Boolean(required=True, dump_default=False)
 
 
 class ServiceAccountWithTokenSchema(ServiceAccountSchema):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     neuro-auth-client==22.2.0
     neuro-logging==21.12.2
     aiohttp-cors==0.7.0
-    marshmallow==3.12.2
+    marshmallow==3.16.0
     aiohttp-apispec==2.2.3
     markupsafe==2.1.1
     alembic==1.7.7
@@ -41,6 +41,7 @@ asyncio_mode = auto
 filterwarnings=
     error
     ignore::DeprecationWarning:jose
+    ignore::marshmallow.warnings.RemovedInMarshmallow4Warning:apispec.ext.marshmallow.field_converter
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
In earlier versions of marshmallow they incorrectly emitted a warning, so it was impossible to silence it only in a perticular module. In 3.16.0 it has been fixed, so we can now silence it only in `apispec.ext.marshmallow.field_converter`.